### PR TITLE
Tap to hide search keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .buildlog/
 .history
 .svn/
+.DS_Store
 
 # IntelliJ related
 *.iml

--- a/CoronaVirusTracker/ContentView.swift
+++ b/CoronaVirusTracker/ContentView.swift
@@ -57,3 +57,9 @@ struct ContentView_Previews: PreviewProvider {
             .environment(\.colorScheme, .dark)
     }
 }
+
+extension UIApplication {
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/CoronaVirusTracker/Services/CoronaAPIService.swift
+++ b/CoronaVirusTracker/Services/CoronaAPIService.swift
@@ -96,7 +96,7 @@ class CoronaArcGISService: CoronaRepositoryService {
     }
     
     func getCases(completion: @escaping (Result<[CoronaCase], CoronaAPIError>) -> ()) {
-        guard let url = generateURL(with: generateURLQueryItems(where: CoronaStatusType.caseWhereQuery, orderByFields: CoronaStatusType.caseOrderByFieldsQuery, resultOffset: 0, resultRecordCount: 250, cacheHint: true)) else {
+        guard let url = generateURL(with: generateURLQueryItems(where: CoronaStatusType.caseWhereQuery, orderByFields: CoronaStatusType.caseOrderByFieldsQuery, resultOffset: 0, resultRecordCount: 500, cacheHint: true)) else {
             completion(.failure(.invalidURL))
             return
         }

--- a/CoronaVirusTracker/Views/Stats/StatsView.swift
+++ b/CoronaVirusTracker/Views/Stats/StatsView.swift
@@ -20,11 +20,17 @@ struct StatsView: View {
                 TotalCountContainerView()
                     .padding(.top)
                     .padding(.horizontal)
+                    .onTapGesture {
+                        UIApplication.shared.endEditing()
+                    }
                 SearchBar(text: $searchTerm, keyboardHeight: $searchBarHeight, placeholder: "Search for a country")
                     .padding(.horizontal).padding(.top)
                 CoronaCaseTableView(searchTerm: $searchTerm)
                     .padding(.horizontal)
                     .padding(.bottom, searchBarHeight)
+                    .onTapGesture {
+                        UIApplication.shared.endEditing()
+                    }
             }
             .background(Color(UIColor.secondarySystemBackground))
             .navigationBarTitle("Corona Virus Tracker", displayMode: .inline)


### PR DESCRIPTION
1. Tap to hide search keyboard
2. Increase default fetch count to 500 so data for US now includes all states